### PR TITLE
`char(1)` の場合に `Lorem ipsum dolor sit ame` をセットしようとしてしまうので。

### DIFF
--- a/Lib/Factory/FabricateModelFactory.php
+++ b/Lib/Factory/FabricateModelFactory.php
@@ -74,7 +74,7 @@ class FabricateModelFactory extends FabricateAbstractFactory {
 					} else {
 						$insert = "Lorem ipsum dolor sit amet";
 						if (!empty($fieldInfo['length'])) {
-							$insert = substr($insert, 0, (int)$fieldInfo['length'] - 2);
+							$insert = substr($insert, 0, (int)$fieldInfo['length'] - 1);
 						}
 					}
 					break;


### PR DESCRIPTION
`substr($insert, 0, (int)$fieldInfo['length'] - 2)` だと `char(1)` の場合に `-1` となり、 `Lorem ipsum dolor sit ame`  という文字列をセットしようとして、`PDOException: SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'hoge' at row 1` というエラーが発生します。

`-2` にしている理由は解りませんでした。何かしら別の対応が必要でしたらお願いします。