### PR TITLE
add max fake text length for text field

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_script:
 
   - sh -c "if [ '$PHPCS' = '1' ]; then composer require squizlabs/php_codesniffer; fi"
 
-  - sh -c "if [ '$COVERALLS' = '1' ]; then composer require --dev satooshi/php-coveralls:dev-master; fi"
+  - sh -c "if [ '$COVERALLS' = '1' ]; then composer require --dev satooshi/php-coveralls:1.0; fi"
   - sh -c "if [ '$COVERALLS' = '1' ]; then mkdir -p build/logs; fi"
 
   - phpenv rehash

--- a/src/Factory/FabricateModelFactory.php
+++ b/src/Factory/FabricateModelFactory.php
@@ -93,6 +93,7 @@ class FabricateModelFactory extends FabricateAbstractFactory
                     break;
                 case 'text':
                     $maxNbChars = !empty($fieldInfo['options']['limit']) ? $fieldInfo['options']['limit'] : 200;
+                    $maxNbChars = $maxNbChars > 200 ? 200 : $maxNbChars;
                     $insert = $this->config->faker->text($maxNbChars);
                     break;
             }


### PR DESCRIPTION
CakePHP 3.2.7の以下の修正の影響で、text型のfakeデータ長に16777215が指定されてデータ生成に非常に時間がかかって、hangしたような状態になるので最大長が200になるように修正しました。

https://github.com/cakephp/cakephp/commit/2784faf#diff-2b4fe0fe80fb9527b279b9b85b7e9258R96

念のため確認したところ、3.2.6まではlimitにはNULLが返ってきていました。
```
3.2.7
string(7) "comment"
array(2) {
  'type' =>
  string(4) "text"
  'options' =>
  array(2) {
    'limit' =>
    int(16777215)
    'null' =>
    bool(true)
  }
}


3.2.6
string(7) "comment"
array(2) {
  ["type"]=>
  string(4) "text"
  ["options"]=>
  array(2) {
    ["limit"]=>
    NULL
    ["null"]=>
    bool(true)
  }
}
```