### PR TITLE
Ensure that $record always exists

### DIFF
--- a/src/Factory/FabricateModelFactory.php
+++ b/src/Factory/FabricateModelFactory.php
@@ -57,6 +57,7 @@ class FabricateModelFactory extends FabricateAbstractFactory
      */
     protected function fakeRecord($tableInfo, $index)
     {
+        $record = [];
         foreach ($tableInfo as $field => $fieldInfo) {
             if (empty($fieldInfo['type'])) {
                 continue;


### PR DESCRIPTION
For certain tables (like join tables where all fields are part of the primary key), no `$record` array is created, resulting in errors and breaking tests. This fixes that by ensuring the `$record` is always declared as an array.