### PR TITLE
Replace String Class To CakeText

### DIFF
--- a/Lib/Factory/FabricateModelFactory.php
+++ b/Lib/Factory/FabricateModelFactory.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 App::uses('FabricateAbstractFactory', 'Fabricate.Lib/Factory');
 
 /**
@@ -70,7 +70,7 @@ class FabricateModelFactory extends FabricateAbstractFactory {
 						isset($fieldInfo['length']) && $fieldInfo['length'] == 36
 					);
 					if ($isPrimaryUuid) {
-						$insert = String::uuid();
+						$insert = CakeText::uuid();
 					} else {
 						$insert = "Lorem ipsum dolor sit amet";
 						if (!empty($fieldInfo['length'])) {


### PR DESCRIPTION
CakePHP2.8系でStringクラスが使えなくなってたので、CakeTextクラスに変更